### PR TITLE
fix filter_last_attempt_grades

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -190,7 +190,7 @@ class assign_feedback_grades_chart extends assign_feedback_plugin {
             $attempt = $singlegrade->attemptnumber;
             if (array_key_exists($userid, $latestgrades)) {
                 $entry = $latestgrades[$userid];
-                $latestattempt = $entry['attempt'];
+                $latestattempt = $entry->attempt;
                 if ($attempt > $latestattempt) {
                     $this->update_user_grade($latestgrades, $userid, $attempt, $grade);
                 }


### PR DESCRIPTION
Looks like there is a mistake trying to reference `attempt` which is a property of `entry`. 
This makes the plugin work for me on Moodle 4.1. Not tested in any other versions. 